### PR TITLE
feat: set history file location using env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+history.txt
 # Created by https://www.gitignore.io/api/rust,linux,macos
 # Edit at https://www.gitignore.io/?templates=rust,linux,macos
 

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,0 @@
-#V2
-::get_contracts
-(+ 2 2)

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -6,7 +6,7 @@ use rustyline::Editor;
 use std::io::{stdin, stdout, Write};
 
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
-
+const HISTORY_FILE: Option<&'static str> = option_env!("CLARITY_REPL_HISTORY_FILE");
 pub struct Terminal {
     session: Session,
 }
@@ -19,13 +19,9 @@ impl Terminal {
     }
 
     pub fn start(&mut self) {
-
         println!("{}", green!(format!("clarity-repl v{}", VERSION.unwrap())));
         println!("{}", black!("Enter \"::help\" for usage hints."));
-        println!(
-            "{}",
-            black!("Connected to a transient in-memory database.")
-        );
+        println!("{}", black!("Connected to a transient in-memory database."));
 
         let (res, _) = self.session.start();
         println!("{}", res);
@@ -61,6 +57,8 @@ impl Terminal {
                 }
             }
         }
-        editor.save_history("history.txt").unwrap();
+        editor
+            .save_history(HISTORY_FILE.unwrap_or("history.txt"))
+            .unwrap();
     }
 }


### PR DESCRIPTION
Addresses #12. Super minor change.

Introduces optional env var `CLARITY_REPL_HISTORY_FILE`.

E.g.:
```bash
export CLARITY_REPL_HISTORY_FILE=~/.clarity_repl_history
clarity-repl
```

