### PR TITLE
feat: multiline entry

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,0 @@
-#V2
-::get_contracts
-(+ 2 2)

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -7,6 +7,25 @@ use std::io::{stdin, stdout, Write};
 
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
+fn complete_input(str: &str) -> Result<Option<char>, (char, char)> {
+    let mut brackets = vec![];
+    for character in str.chars() {
+        match character {
+            '(' | '{' => brackets.push(character),
+            ')' | '}' => match (brackets.pop(), character) {
+                (Some('('), '}') => return Err((')', '}')),
+                (Some('{'), ')') => return Err(('}', ')')),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    match brackets.last() {
+        Some(char) => Ok(Some(*char)),
+        _ => Ok(None),
+    }
+}
+
 pub struct Terminal {
     session: Session,
 }
@@ -19,29 +38,47 @@ impl Terminal {
     }
 
     pub fn start(&mut self) {
-
         println!("{}", green!(format!("clarity-repl v{}", VERSION.unwrap())));
         println!("{}", black!("Enter \"::help\" for usage hints."));
-        println!(
-            "{}",
-            black!("Connected to a transient in-memory database.")
-        );
+        println!("{}", black!("Connected to a transient in-memory database."));
 
         let (res, _) = self.session.start();
         println!("{}", res);
-
         let mut editor = Editor::<()>::new();
         let mut ctrl_c_acc = 0;
+        let mut input_buffer = String::new();
+        let mut prompt = String::from(">> ");
         loop {
-            let readline = editor.readline(">> ");
+            let readline = editor.readline(prompt.as_str());
             match readline {
                 Ok(command) => {
-                    let output = self.session.handle_command(&command);
-                    for line in output {
-                        println!("{}", line);
-                    }
                     ctrl_c_acc = 0;
-                    editor.add_history_entry(command.as_str());
+                    if !input_buffer.is_empty() {
+                        input_buffer.push_str("\n");
+                    }
+                    input_buffer.push_str(&command);
+                    match complete_input(&input_buffer) {
+                        Ok(None) => {
+                            let output = self.session.handle_command(&input_buffer);
+                            for line in output {
+                                println!("{}", line);
+                            }
+                            prompt = String::from(">> ");
+                            editor.add_history_entry(input_buffer.as_str());
+                            input_buffer.clear();
+                        }
+                        Ok(Some(str)) => {
+                            prompt = format!("{}.. ", str);
+                        }
+                        Err((expected, got)) => {
+                            println!("Error: expected closing {}, got {}", expected, got);
+                            if input_buffer.len() == command.len() {
+                                input_buffer.clear();
+                            } else {
+                                input_buffer.truncate(input_buffer.len() - command.len() - 1);
+                            }
+                        }
+                    }
                 }
                 Err(ReadlineError::Interrupted) => {
                     ctrl_c_acc += 1;

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -46,25 +46,23 @@ impl Terminal {
         println!("{}", res);
         let mut editor = Editor::<()>::new();
         let mut ctrl_c_acc = 0;
-        let mut input_buffer = String::new();
+        let mut input_buffer = vec![];
         let mut prompt = String::from(">> ");
         loop {
             let readline = editor.readline(prompt.as_str());
             match readline {
                 Ok(command) => {
                     ctrl_c_acc = 0;
-                    if !input_buffer.is_empty() {
-                        input_buffer.push_str("\n");
-                    }
-                    input_buffer.push_str(&command);
-                    match complete_input(&input_buffer) {
+                    input_buffer.push(command);
+                    let input = input_buffer.join("\n");
+                    match complete_input(&input) {
                         Ok(None) => {
-                            let output = self.session.handle_command(&input_buffer);
+                            let output = self.session.handle_command(&input);
                             for line in output {
                                 println!("{}", line);
                             }
                             prompt = String::from(">> ");
-                            editor.add_history_entry(input_buffer.as_str());
+                            editor.add_history_entry(&input);
                             input_buffer.clear();
                         }
                         Ok(Some(str)) => {
@@ -72,11 +70,7 @@ impl Terminal {
                         }
                         Err((expected, got)) => {
                             println!("Error: expected closing {}, got {}", expected, got);
-                            if input_buffer.len() == command.len() {
-                                input_buffer.clear();
-                            } else {
-                                input_buffer.truncate(input_buffer.len() - command.len() - 1);
-                            }
+                            input_buffer.pop();
                         }
                     }
                 }


### PR DESCRIPTION
Adds the ability to write Clarity over multiple lines. It counts open braces and will hint the last brace type you are in. The feature makes it easier to write Clarity interactively as you are not forced to either (a) write the whole function definition in a single line, or (b) write code in a different editor and then paste it into the REPL. If you close the braces in the wrong order, it discards the input and allows you to recover (See last example).

Looks like this (every line was followed by a line-feed, notice the prompt changes):

```
clarity-repl v0.12.2
Enter "::help" for usage hints.
Connected to a transient in-memory database.

>> (+ 1 2)
3
>> (+
(.. 1
(.. 2
(.. 3
(.. )
6
>> (define-public (example)
(.. (ok true)
(.. )
→ .ST000000000000000000002AMW42H.contract-2 contract successfully stored. Use (contract-call? ...) for invoking the public functions:
>> {
{.. key: "val"
{.. }
{key: "val"}
>> (+
(.. }
Error: expected closing ), got }
(.. 1 2)
3
```

I know `rustyline` has a `Validator` trait but it did not seem to give me the flexibility I desired (like changing the prompt.)