### PR TITLE
fix: bump tokio to 1.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libsecp256k1 = "0.3.5"
 serde_stacker = "0.1"
 rand = "=0.7.3"
 atty = "0.2.14"
-tokio = { version = "=1.6.3", features = ["rt", "rt-multi-thread"], optional = true }
+tokio = { version = "=1.8.1", features = ["rt", "rt-multi-thread"], optional = true }
 
 # CLI
 pico-args = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clarity-repl"
 description = "Clarity REPL"
-version = "0.13.2"
+version = "0.13.4"
 authors = ["Ludo Galabru <ludovic@galabru.com>"]
 readme = "README.md"
 edition = "2018"
@@ -27,7 +27,7 @@ libsecp256k1 = "0.3.5"
 serde_stacker = "0.1"
 rand = "=0.7.3"
 atty = "0.2.14"
-tokio = { version = "=1.6.1", features = ["rt", "rt-multi-thread"], optional = true }
+tokio = { version = "=1.6.3", features = ["rt", "rt-multi-thread"], optional = true }
 
 # CLI
 pico-args = { version = "0.4.0", optional = true }


### PR DESCRIPTION
* Bumps `tokio` dependency to `1.6.3`
* Updates clarity-repl version, since `0.13.3` is available in crates.io