### PR TITLE
fix: NFT count in ::get_assets_maps was debited, not credited

### DIFF
--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -315,7 +315,7 @@ impl ClarityInterpreter {
                     StacksTransactionEvent::NFTEvent(NFTEventType::NFTMintEvent(
                         ref event_data,
                     )) => {
-                        accounts_to_debit.push((
+                        accounts_to_credit.push((
                             event_data.recipient.to_string(),
                             event_data.asset_identifier.sugared(),
                             1,


### PR DESCRIPTION
Fixes hirosystems/clarinet#112.

The bug can be seen by minting an NFT.  Example:
```
>> (contract-call? .velocity claim)
Events emitted
{"type":"nft_mint_event","nft_mint_event":{"asset_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.velocity::velocity","recipient":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM","value":"u1"}}
(ok u1)
>> ::get_assets_maps
+------------------------------------------------------+--------------------+-----------------+
| Address                                              | .velocity.velocity | STX             |
+------------------------------------------------------+--------------------+-----------------+
| ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM (deployer) | 1                  | 100000000000000 |
+------------------------------------------------------+--------------------+-----------------+
> (contract-call? .velocity claim)
Events emitted
{"type":"nft_mint_event","nft_mint_event":{"asset_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.velocity::velocity","recipient":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM","value":"u2"}}
(ok u2)
>> (contract-call? .velocity claim)
Events emitted
{"type":"nft_mint_event","nft_mint_event":{"asset_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.velocity::velocity","recipient":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM","value":"u3"}}
(ok u3)
>> ::get_assets_maps
+------------------------------------------------------+-----------------------------------------+-----------------+
| Address                                              | .velocity.velocity                      | STX             |
+------------------------------------------------------+-----------------------------------------+-----------------+
| ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM (deployer) | 340282366920938463463374607431768211455 | 100000000000000 |
+------------------------------------------------------+-----------------------------------------+-----------------+
>> (contract-call? .velocity claim)
Events emitted
{"type":"nft_mint_event","nft_mint_event":{"asset_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.velocity::velocity","recipient":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM","value":"u4"}}
(ok u4)
>> ::get_assets_maps
+------------------------------------------------------+-----------------------------------------+-----------------+
| Address                                              | .velocity.velocity                      | STX             |
+------------------------------------------------------+-----------------------------------------+-----------------+
| ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM (deployer) | 340282366920938463463374607431768211454 | 100000000000000 |
+------------------------------------------------------+-----------------------------------------+-----------------+
>>
```