### PR TITLE
feat: load history file on cli startup, if present

### DIFF
--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -55,6 +55,10 @@ impl Terminal {
         let mut ctrl_c_acc = 0;
         let mut input_buffer = vec![];
         let mut prompt = String::from(">> ");
+
+        editor
+            .load_history(HISTORY_FILE.unwrap_or("history.txt"))
+            .ok();
         loop {
             let readline = editor.readline(prompt.as_str());
             match readline {


### PR DESCRIPTION
This makes clarinet's console a lot more useful: load a previous session's history file if it's present.