### PR TITLE
ci: automate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           extra_plugins: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           LLVM_PROFILE_FILE: "clarity-repl-%p-%m.profraw"
-        run: cargo build --locked && cargo test
+        run: cargo build && cargo test
 
       - name: Generate coverage
         run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
@@ -162,7 +162,7 @@ jobs:
           path: target/wasm32-unknown-unknown/release/clarity_repl.wasm
 
       - name: Unit Tests - Cargo
-        run: cargo test --release --locked --target ${{ matrix.target }}
+        run: cargo test --release
 
       - name: Publish clarity-repl to crates.io
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,62 @@
+name: CI
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+    paths-ignore:
+      - "**/CHANGELOG.md"
+      - "**/package.json"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  pre_run:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@ad6cb1b847ffb509a69b745b6ee2f1d14dfe14b8
+        with:
+          access_token: ${{ github.token }}
+
+  audit:
+    name: Audit and format
+    runs-on: ubuntu-latest
+    needs: pre_run
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt
+          override: true
+
+      - name: Set Cargo file permissions
+        run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install dependencies
+        run: cargo install cargo-audit
+
+      - name: Run audit
+        run: cargo audit --ignore RUSTSEC-2021-0119
+
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,12 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v2
         with:
-          path: ~/.cargo/
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install dependencies
@@ -78,8 +83,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/
-            target/release/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install dependencies
@@ -91,5 +99,53 @@ jobs:
       - name: Build - WASM
         run: wasm-pack build --target web --release -- --no-default-features --features wasm
 
-      - name: debug
-        run: ls -la target/**/*
+      - name: Upload clarity-repl to workflow run
+        uses: actions/upload-artifact@v2
+        with:
+          name: clarity-repl
+          path: target/release/clarity-repl
+
+      - name: Upload wasm to workflow run
+        uses: actions/upload-artifact@v2
+        with:
+          name: clarity_repl.wasm
+          path: target/wasm32-unknown-unknown/release/clarity_repl.wasm
+
+      - name: Publish clarity-repl to crates.io
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cargo login ${{ secrets.CARGO_CRATES_IO_API_KEY }}
+          cargo publish
+
+      - name: Upload wasm to GH release
+        uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/wasm32-unknown-unknown/release/clarity_repl.wasm
+          tag: ${{ github.ref }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'main')
+    needs:
+      - audit
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Necessary for Semantic Release
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/exec
+            @semantic-release/git

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,4 +91,4 @@ jobs:
         run: wasm-pack build --target web --release -- --no-default-features --features wasm
 
       - name: debug
-        run: ls -la target/*
+        run: ls -la target/**/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,14 @@ jobs:
           components: rustfmt
           override: true
 
-      - name: Install dependencies
-        run: cargo install cargo-audit
-
       - name: Cache cargo
         uses: actions/cache@v2
         with:
           path: ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install dependencies
+        run: cargo install cargo-audit
 
       - name: Run audit
         run: cargo audit --ignore RUSTSEC-2021-0119
@@ -73,8 +73,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install dependencies
-        run: cargo install wasm-pack
 
       - name: Cache cargo
         uses: actions/cache@v2
@@ -83,6 +81,9 @@ jobs:
             ~/.cargo/
             target/release/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install dependencies
+        run: cargo install wasm-pack
 
       - name: Build - Cargo
         run: cargo build --release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,6 @@ jobs:
           components: rustfmt
           override: true
 
-      - name: Set Cargo file permissions
-        run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
-
       - name: Cache cargo
         uses: actions/cache@v2
         with:
@@ -60,3 +57,42 @@ jobs:
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 
+  build:
+    name: Build clarity-repl and WASM
+    runs-on: ubuntu-latest
+    needs: pre_run
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/release/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install dependencies
+        run: cargo install wasm-pack
+
+      - name: Build - Cargo
+        run: cargo build --release --locked
+
+      - name: Build - WASM
+        run: wasm-pack build --target web --release -- --no-default-features --features wasm
+
+      - name: debug
+        run: ls -la target/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,14 @@ jobs:
           components: rustfmt
           override: true
 
+      - name: Install dependencies
+        run: cargo install cargo-audit
+
       - name: Cache cargo
         uses: actions/cache@v2
         with:
           path: ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install dependencies
-        run: cargo install cargo-audit
 
       - name: Run audit
         run: cargo audit --ignore RUSTSEC-2021-0119
@@ -58,7 +58,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   build:
-    name: Build clarity-repl and WASM
+    name: Build
     runs-on: ubuntu-latest
     needs: pre_run
 
@@ -70,26 +70,22 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           profile: minimal
           override: true
+
+      - name: Install dependencies
+        run: cargo install wasm-pack
 
       - name: Cache cargo
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/
             target/release/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install dependencies
-        run: cargo install wasm-pack
-
       - name: Build - Cargo
-        run: cargo build --release --locked
+        run: cargo build --release
 
       - name: Build - WASM
         run: wasm-pack build --target web --release -- --no-default-features --features wasm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,56 @@ jobs:
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: pre_run
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-08-05
+          profile: minimal
+          components: llvm-tools-preview
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        id: cache-cargo
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        run: cargo install grcov
+
+      - name: Unit Tests
+        env:
+          RUSTFLAGS: "-Zinstrument-coverage"
+          LLVM_PROFILE_FILE: "clarity-repl-%p-%m.profraw"
+        run: cargo build --locked && cargo test
+
+      - name: Generate coverage
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          name: clarity-repl
+          verbose: true
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -111,6 +161,9 @@ jobs:
           name: clarity_repl.wasm
           path: target/wasm32-unknown-unknown/release/clarity_repl.wasm
 
+      - name: Unit Tests - Cargo
+        run: cargo test --release --locked --target ${{ matrix.target }}
+
       - name: Publish clarity-repl to crates.io
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -132,6 +185,7 @@ jobs:
     needs:
       - audit
       - build
+      - test
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run audit
         run: cargo audit --ignore RUSTSEC-2021-0119
@@ -82,7 +82,7 @@ jobs:
           path: |
             ~/.cargo/
             target/release/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build - Cargo
         run: cargo build --release

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ Cargo.lock
 **/*.rs.bk
 
 # End of https://www.gitignore.io/api/rust,linux,macos
+
+# Node.js
+**/node_modules
+package-lock.json

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "clarity-repl"
-description = "Clarity REPL"
 version = "0.16.0"
+description = "Clarity REPL"
 authors = ["Ludo Galabru <ludovic@galabru.com>"]
 readme = "README.md"
 edition = "2018"
 license = "GPL-3.0-only"
 keywords = ["blockstack", "blockchain", "clarity", "smart-contract", "repl"]
-exclude = ["vs-client/**"]
+exclude = [
+    "vs-client/**",
+    ".husky",
+    ".git*"
+    ]
 homepage = "https://lgalabru.github.io/clarity-repl/"
 repository = "https://github.com/lgalabru/clarity-repl"
 categories = ["command-line-utilities", "development-tools", "development-tools::build-utils"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "@hiro/clarity-repl",
+    "description": "A read–eval–print loop program for Clarity, a decidable smart contract language",
+    "commitlint": {
+        "extends": [
+            "@commitlint/config-conventional"
+        ]
+    },
+    "husky": {
+        "hooks": {
+            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+    },
+    "release": {
+        "branches": [
+            "main"
+        ],
+        "plugins": [
+            "@semantic-release/commit-analyzer",
+            "@semantic-release/release-notes-generator",
+            [
+                "@semantic-release/exec",
+                {
+                    "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"clarity-repl\"\\nversion = \"[^\"]*\"@name = \"clarity-repl\"\\nversion = \"${nextRelease.version}\"@g' Cargo.toml"
+                }
+            ],
+            [
+                "@semantic-release/npm",
+                {
+                    "pkgRoot": "./pkg",
+                    "npmPublish": true
+                }
+            ],
+            "@semantic-release/github",
+            "@semantic-release/changelog",
+            [
+                "@semantic-release/git",
+                {
+                    "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
+                    "assets": [
+                        "CHANGELOG.md",
+                        "Cargo.toml"
+                    ]
+                }
+            ]
+        ]
+    },
+    "scripts": {
+        "prepare": "husky install"
+    },
+    "devDependencies": {
+        "@commitlint/cli": "^14.1.0",
+        "@commitlint/config-conventional": "^14.1.0",
+        "husky": "^7.0.4"
+    }
+}

--- a/src/clarity/contexts.rs
+++ b/src/clarity/contexts.rs
@@ -435,8 +435,9 @@ impl<'a> OwnedEnvironment<'a> {
 
     #[cfg(test)]
     pub fn new_max_limit(mut database: ClarityDatabase<'a>) -> OwnedEnvironment<'a> {
-        let cost_track = LimitedCostTracker::new_max_limit(&mut database)
-            .expect("FAIL: problem instantiating cost tracking");
+        let cost_track =
+            LimitedCostTracker::new(false, ExecutionCost::max_value(), &mut database, 0)
+                .expect("FAIL: problem instantiating cost tracking");
 
         OwnedEnvironment {
             context: GlobalContext::new(false, database, cost_track),

--- a/src/clarity/contexts.rs
+++ b/src/clarity/contexts.rs
@@ -11,7 +11,7 @@ use crate::clarity::costs::cost_functions::ClarityCostFunction;
 use crate::clarity::costs::{
     cost_functions, runtime_cost, CostErrors, CostTracker, ExecutionCost, LimitedCostTracker,
 };
-use crate::clarity::coverage::{TestCoverageReport, CostsReport};
+use crate::clarity::coverage::{CostsReport, TestCoverageReport};
 use crate::clarity::database::structures::{
     DataMapMetadata, DataVariableMetadata, FungibleTokenMetadata, NonFungibleTokenMetadata,
 };

--- a/src/clarity/costs/mod.rs
+++ b/src/clarity/costs/mod.rs
@@ -600,10 +600,11 @@ impl LimitedCostTracker {
         let CostStateSummary {
             contract_call_circuits,
             mut cost_function_references,
-        } = load_cost_functions(self.mainnet, clarity_db, apply_updates, self.costs_version).map_err(|e| {
-            clarity_db.roll_back();
-            e
-        })?;
+        } = load_cost_functions(self.mainnet, clarity_db, apply_updates, self.costs_version)
+            .map_err(|e| {
+                clarity_db.roll_back();
+                e
+            })?;
 
         self.contract_call_circuits = contract_call_circuits;
 

--- a/src/clarity/coverage.rs
+++ b/src/clarity/coverage.rs
@@ -31,8 +31,7 @@ pub struct ContractCoverageReport {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct CostsReport {
-}
+pub struct CostsReport {}
 
 impl CoverageReporter {
     pub fn new() -> CoverageReporter {

--- a/src/clarity/mod.rs
+++ b/src/clarity/mod.rs
@@ -256,8 +256,8 @@ pub fn eval<'a>(
                         bp.identifier.push_str(&format!("${}", exp.id))
                     }
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         };
     }
     res

--- a/src/clarity/util/bitcoin/blockdata/transaction.rs
+++ b/src/clarity/util/bitcoin/blockdata/transaction.rs
@@ -64,8 +64,8 @@ impl OutPoint {
     /// # Examples
     ///
     /// ```rust
-    /// use blockstack_libcrate::clarity::util::bitcoin::blockdata::constants::genesis_block;
-    /// use blockstack_libcrate::clarity::util::bitcoin::network::constants::Network;
+    /// use clarity_repl::clarity::util::bitcoin::blockdata::constants::genesis_block;
+    /// use clarity_repl::clarity::util::bitcoin::network::constants::Network;
     ///
     /// let block = genesis_block(Network::Bitcoin);
     /// let tx = &block.txdata[0];

--- a/src/clarity/util/bitcoin/internal_macros.rs
+++ b/src/clarity/util/bitcoin/internal_macros.rs
@@ -217,6 +217,7 @@ macro_rules! display_from_debug {
 }
 
 #[cfg(test)]
+#[cfg_attr(test, allow(unused_macros))]
 macro_rules! hex_script (($s:expr) => (crate::clarity::util::bitcoin::blockdata::script::Script::from(::util::hash::hex_bytes($s).unwrap())));
 
 macro_rules! serde_struct_impl {

--- a/src/clarity/util/bitcoin/network/constants.rs
+++ b/src/clarity/util/bitcoin/network/constants.rs
@@ -28,8 +28,8 @@
 //! # Example: encoding a network's magic bytes
 //!
 //! ```rust
-//! use blockstack_libcrate::clarity::util::bitcoin::network::constants::Network;
-//! use blockstack_libcrate::clarity::util::bitcoin::network::serialize::serialize;
+//! use clarity_repl::clarity::util::bitcoin::network::constants::Network;
+//! use clarity_repl::clarity::util::bitcoin::network::serialize::serialize;
 //!
 //! let network = Network::Bitcoin;
 //! let bytes = serialize(&network).unwrap();
@@ -66,7 +66,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use blockstack_libcrate::clarity::util::bitcoin::network::constants::Network;
+    /// use clarity_repl::clarity::util::bitcoin::network::constants::Network;
     ///
     /// assert_eq!(Some(Network::Bitcoin), Network::from_magic(0xD9B4BEF9));
     /// assert_eq!(None, Network::from_magic(0xFFFFFFFF));
@@ -87,7 +87,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use blockstack_libcrate::clarity::util::bitcoin::network::constants::Network;
+    /// use clarity_repl::clarity::util::bitcoin::network::constants::Network;
     ///
     /// let network = Network::Bitcoin;
     /// assert_eq!(network.magic(), 0xD9B4BEF9);

--- a/src/clarity/util/bitcoin/network/encodable.rs
+++ b/src/clarity/util/bitcoin/network/encodable.rs
@@ -538,27 +538,27 @@ mod tests {
     fn deserialize_nonminimal_vec() {
         match deserialize::<Vec<u8>>(&[0xfd, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
         match deserialize::<Vec<u8>>(&[0xfd, 0xfc, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
         match deserialize::<Vec<u8>>(&[0xfe, 0xff, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
         match deserialize::<Vec<u8>>(&[0xfe, 0xff, 0xff, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
         match deserialize::<Vec<u8>>(&[0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
         match deserialize::<Vec<u8>>(&[0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => panic!("{:?}", x),
         }
 
         let mut vec_256 = vec![0; 259];

--- a/src/clarity/util/retry.rs
+++ b/src/clarity/util/retry.rs
@@ -168,11 +168,12 @@ mod test {
         let mut tmp_buf = [0u8; 3];
         let e = retry_reader.read_exact(&mut tmp_buf);
         let e_str = format!("{:?}", &e);
-        assert!(e.is_err(), e_str);
+        assert!(e.is_err(), "{}", e_str);
         assert!(
             format!("{:?}", &e.unwrap_err())
                 .find("failed to fill whole buffer")
                 .is_some(),
+            "{}",
             e_str
         );
 


### PR DESCRIPTION
Closes https://github.com/hirosystems/clarity-repl/issues/28

Added a CI workflow to perform the following:
* Audits and format checks
* Build the clarity-repl and wasm on PRs
* Create a GH release and git tag on the `main` branch when appropriate (following @[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
* Upload the clarity-repl WASM artifact to the GH release
* Publish the clarity-repl WASM NPM package
* Publish clarity-repl crate to creates.io

Also added a commit hook to check for commit messages which fit the conventional commit style.

No tests run for CI yet since there are none, but this step can be added once tests are merged in to `main`.