### PR TITLE
Improved MARF emulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ integer-sqrt = "0.1.3"
 libsecp256k1 = "0.5.0"
 serde_stacker = "0.1"
 rand = "=0.7.3"
+rand_pcg = "0.3.1"
+rand_seeder = "0.2.2"
 atty = "0.2.14"
 tokio = { version = "=1.8.1", features = ["rt", "rt-multi-thread"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ integer-sqrt = "0.1.3"
 libsecp256k1 = "0.5.0"
 serde_stacker = "0.1"
 rand = "=0.7.3"
+getrandom = { version = "0.2.3", features = ["js"] }
 rand_pcg = "0.3.1"
 rand_seeder = "0.2.2"
 atty = "0.2.14"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -41,7 +41,7 @@ fn main() {
         Some(code_str) => {
             let mut session = Session::new(settings);
             match session.start() {
-                Ok(_) => {}
+                Ok(_) => {},
                 Err(e) => {
                     println!("{}", e);
                     std::process::exit(1);
@@ -52,7 +52,7 @@ fn main() {
             for line in output {
                 println!("{}", line);
             }
-        }
+        },
         None => {
             let mut terminal = Terminal::new(settings);
             terminal.start();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -41,7 +41,7 @@ fn main() {
         Some(code_str) => {
             let mut session = Session::new(settings);
             match session.start() {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     println!("{}", e);
                     std::process::exit(1);
@@ -52,7 +52,7 @@ fn main() {
             for line in output {
                 println!("{}", line);
             }
-        },
+        }
         None => {
             let mut terminal = Terminal::new(settings);
             terminal.start();

--- a/src/clarity/database/clarity_db.rs
+++ b/src/clarity/database/clarity_db.rs
@@ -1,6 +1,6 @@
 use rand_pcg::Pcg64;
-use rand_seeder::Seeder;
 use rand_seeder::rand_core::RngCore;
+use rand_seeder::Seeder;
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 

--- a/src/clarity/database/clarity_db.rs
+++ b/src/clarity/database/clarity_db.rs
@@ -1,4 +1,6 @@
-use rand::RngCore;
+use rand_pcg::Pcg64;
+use rand_seeder::Seeder;
+use rand_seeder::rand_core::RngCore;
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 
@@ -78,8 +80,8 @@ impl HeadersDB for NullHeadersDB {
         Some(burn_header_hash)
     }
 
-    fn get_vrf_seed_for_block(&self, _bhh: &StacksBlockId) -> Option<VRFSeed> {
-        let mut rng = rand::thread_rng();
+    fn get_vrf_seed_for_block(&self, bhh: &StacksBlockId) -> Option<VRFSeed> {
+        let mut rng: Pcg64 = Seeder::from(bhh).make_rng();
         let mut buf = [0u8; 32];
         rng.fill_bytes(&mut buf);
         Some(VRFSeed(buf))

--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -67,6 +67,7 @@ impl Datastore {
 
         self.chain_height = self.chain_height + count;
         self.open_chain_tip = height_to_id(self.chain_height);
+        self.current_chain_tip = self.open_chain_tip;
         self.chain_height
     }
 }
@@ -80,7 +81,7 @@ impl ClarityBackingStore for Datastore {
 
     /// fetch K-V out of the committed datastore
     fn get(&mut self, key: &str) -> Option<String> {
-        if let Some(map) = self.store.get(&self.open_chain_tip) {
+        if let Some(map) = self.store.get(&self.current_chain_tip) {
             map.get(key).map(|v| v.clone())
         } else {
             panic!("Block does not exist for current chain tip");
@@ -96,7 +97,7 @@ impl ClarityBackingStore for Datastore {
     /// returns the previous block header hash on success
     fn set_block_hash(&mut self, bhh: StacksBlockId) -> Result<StacksBlockId> {
         let prior_tip = self.open_chain_tip;
-        self.open_chain_tip = bhh;
+        self.current_chain_tip = bhh;
         Ok(prior_tip)
     }
 
@@ -205,11 +206,11 @@ impl Datastore {
         //     .expect("ERROR: Failed to commit MARF block");
     }
     pub fn get_chain_tip(&self) -> &StacksBlockId {
-        &self.open_chain_tip
+        &self.current_chain_tip
     }
 
     pub fn set_chain_tip(&mut self, bhh: &StacksBlockId) {
-        self.open_chain_tip = bhh.clone();
+        self.current_chain_tip = bhh.clone();
     }
 
     pub fn put(&mut self, key: &str, value: &str) {

--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -70,10 +70,11 @@ impl ClarityBackingStore for Datastore {
 
     /// fetch K-V out of the committed datastore
     fn get(&mut self, key: &str) -> Option<String> {
-        self.store
-            .get(&self.chain_tip)
-            .map(|kv_store| kv_store.get(key).map(|v| v.clone()))
-            .flatten()
+        if let Some(map) = self.store.get(&self.chain_tip) {
+            map.get(key).map(|v| v.clone())
+        } else {
+            panic!("Block does not exist for current chain tip");
+        }
     }
 
     fn has_entry(&mut self, key: &str) -> bool {
@@ -204,6 +205,8 @@ impl Datastore {
     pub fn put(&mut self, key: &str, value: &str) {
         if let Some(map) = self.store.get_mut(&self.chain_tip) {
             map.insert(key.to_string(), value.to_string());
+        } else {
+            panic!("Block does not exist for current chain tip");
         }
     }
 

--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -15,8 +15,10 @@ use std::hash::Hash;
 pub struct Datastore {
     store: HashMap<StacksBlockId, HashMap<String, String>>,
     metadata: HashMap<(String, String), String>,
-    chain_tip: StacksBlockId,
+    open_chain_tip: StacksBlockId,
+    current_chain_tip: StacksBlockId,
     chain_height: u32,
+    height_at_chain_tip: HashMap<StacksBlockId, u32>,
 }
 
 fn height_to_id(height: u32) -> StacksBlockId {
@@ -34,11 +36,16 @@ impl Datastore {
         let mut store = HashMap::new();
         store.insert(id, HashMap::new());
 
+        let mut id_height_map = HashMap::new();
+        id_height_map.insert(id, 0);
+
         Datastore {
             store,
             metadata: HashMap::new(),
-            chain_tip: height_to_id(0),
+            open_chain_tip: id,
+            current_chain_tip: id,
             chain_height: 0,
+            height_at_chain_tip: id_height_map,
         }
     }
 
@@ -46,17 +53,20 @@ impl Datastore {
         let cur_height = self.chain_height;
 
         for i in 1..=count {
-            let id = height_to_id(i);
+            let height = cur_height + i;
+            let id = height_to_id(height);
             self.store.insert(id, self.store
-                .get(&self.chain_tip)
+                .get(&self.open_chain_tip)
                 .expect(
                     format!("Block at current height {} does not exist", cur_height).as_str(),
                 )
                 .clone());
+            
+            self.height_at_chain_tip.insert(id, height);
         }
 
         self.chain_height = self.chain_height + count;
-        self.chain_tip = height_to_id(self.chain_height);
+        self.open_chain_tip = height_to_id(self.chain_height);
         self.chain_height
     }
 }
@@ -70,7 +80,7 @@ impl ClarityBackingStore for Datastore {
 
     /// fetch K-V out of the committed datastore
     fn get(&mut self, key: &str) -> Option<String> {
-        if let Some(map) = self.store.get(&self.chain_tip) {
+        if let Some(map) = self.store.get(&self.open_chain_tip) {
             map.get(key).map(|v| v.clone())
         } else {
             panic!("Block does not exist for current chain tip");
@@ -85,8 +95,8 @@ impl ClarityBackingStore for Datastore {
     ///   used to implement time-shifted evaluation.
     /// returns the previous block header hash on success
     fn set_block_hash(&mut self, bhh: StacksBlockId) -> Result<StacksBlockId> {
-        let prior_tip = self.chain_tip;
-        self.chain_tip = bhh;
+        let prior_tip = self.open_chain_tip;
+        self.open_chain_tip = bhh;
         Ok(prior_tip)
     }
 
@@ -98,16 +108,16 @@ impl ClarityBackingStore for Datastore {
     ///  i.e., it changes on time-shifted evaluation. the open_chain_tip functions always
     ///   return data about the chain tip that is currently open for writing.
     fn get_current_block_height(&mut self) -> u32 {
-        self.chain_height.clone()
-    }
+        self.height_at_chain_tip.get(self.get_chain_tip())
+            .expect("No height stored for current chain tip")
+            .clone()    }
 
-    // TODO: fix this
     fn get_open_chain_tip_height(&mut self) -> u32 {
         self.chain_height.clone()
     }
 
     fn get_open_chain_tip(&mut self) -> StacksBlockId {
-        self.chain_tip.clone()
+        self.open_chain_tip.clone()
     }
 
     /// The contract commitment is the hash of the contract, plus the block height in
@@ -195,15 +205,15 @@ impl Datastore {
         //     .expect("ERROR: Failed to commit MARF block");
     }
     pub fn get_chain_tip(&self) -> &StacksBlockId {
-        &self.chain_tip
+        &self.open_chain_tip
     }
 
     pub fn set_chain_tip(&mut self, bhh: &StacksBlockId) {
-        self.chain_tip = bhh.clone();
+        self.open_chain_tip = bhh.clone();
     }
 
     pub fn put(&mut self, key: &str, value: &str) {
-        if let Some(map) = self.store.get_mut(&self.chain_tip) {
+        if let Some(map) = self.store.get_mut(&self.open_chain_tip) {
             map.insert(key.to_string(), value.to_string());
         } else {
             panic!("Block does not exist for current chain tip");

--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -81,7 +81,9 @@ impl ClarityBackingStore for Datastore {
 
     /// fetch K-V out of the committed datastore
     fn get(&mut self, key: &str) -> Option<String> {
-        let lookup_id = self.block_id_lookup.get(&self.current_chain_tip)
+        let lookup_id = self
+            .block_id_lookup
+            .get(&self.current_chain_tip)
             .expect("Could not find current chain tip in block_id_lookup map");
 
         if let Some(map) = self.store.get(lookup_id) {
@@ -112,9 +114,11 @@ impl ClarityBackingStore for Datastore {
     ///  i.e., it changes on time-shifted evaluation. the open_chain_tip functions always
     ///   return data about the chain tip that is currently open for writing.
     fn get_current_block_height(&mut self) -> u32 {
-        self.height_at_chain_tip.get(self.get_chain_tip())
+        self.height_at_chain_tip
+            .get(self.get_chain_tip())
             .expect("No height stored for current chain tip")
-            .clone()    }
+            .clone()
+    }
 
     fn get_open_chain_tip_height(&mut self) -> u32 {
         self.chain_height.clone()
@@ -217,20 +221,24 @@ impl Datastore {
     }
 
     pub fn put(&mut self, key: &str, value: &str) {
-        let lookup_id = self.block_id_lookup.get(&self.open_chain_tip)
+        let lookup_id = self
+            .block_id_lookup
+            .get(&self.open_chain_tip)
             .expect("Could not find current chain tip in block_id_lookup map");
 
         // if there isn't a store for the open chain_tip, make one and update the
         // entry for the block id in the lookup table
         if *lookup_id != self.open_chain_tip {
-            self.store.insert(self.open_chain_tip, self.store
-                .get(lookup_id)
-                .expect(
-                    format!("Block with ID {:?} does not exist", lookup_id).as_str(),
-                )
-                .clone());
+            self.store.insert(
+                self.open_chain_tip,
+                self.store
+                    .get(lookup_id)
+                    .expect(format!("Block with ID {:?} does not exist", lookup_id).as_str())
+                    .clone(),
+            );
 
-            self.block_id_lookup.insert(self.open_chain_tip, self.current_chain_tip);
+            self.block_id_lookup
+                .insert(self.open_chain_tip, self.current_chain_tip);
         }
 
         if let Some(map) = self.store.get_mut(&self.open_chain_tip) {

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -40,8 +40,7 @@ pub struct ClarityInterpreter {
 
 impl ClarityInterpreter {
     pub fn new(tx_sender: StandardPrincipalData, costs_version: u32) -> ClarityInterpreter {
-        let mut datastore = Datastore::new();
-        datastore.advance_chain_tip(1);
+        let datastore = Datastore::new();
         let accounts = BTreeSet::new();
         let tokens = BTreeMap::new();
         ClarityInterpreter {

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -40,7 +40,8 @@ pub struct ClarityInterpreter {
 
 impl ClarityInterpreter {
     pub fn new(tx_sender: StandardPrincipalData, costs_version: u32) -> ClarityInterpreter {
-        let datastore = Datastore::new();
+        let mut datastore = Datastore::new();
+        datastore.advance_chain_tip(1);
         let accounts = BTreeSet::new();
         let tokens = BTreeMap::new();
         ClarityInterpreter {

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -1338,6 +1338,7 @@ mod tests {
             green!("u1")
         );
         assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u0)) (contract-call? .contract-2 get-x))")[0], green!("u0"));
+        assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u5000)) (contract-call? .contract-2 get-x))")[0], green!("u0"));
 
         // advance chain tip again and test at-block
         session.advance_chain_tip(10);

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -1307,7 +1307,8 @@ mod tests {
         session.start().expect("session could not start");
 
         // setup contract state
-        session.handle_command("
+        session.handle_command(
+            "
             (define-data-var x uint u0)
 
             (define-read-only (get-x)
@@ -1316,23 +1317,39 @@ mod tests {
             (define-public (incr)
                 (begin
                     (var-set x (+ (var-get x) u1))
-                    (ok (var-get x))))");
-        
+                    (ok (var-get x))))",
+        );
+
         // assert data-var is set to 0
-        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u0"));
+        assert_eq!(
+            session.handle_command("(contract-call? .contract-2 get-x)")[0],
+            green!("u0")
+        );
 
         // advance chain tip and test at-block
         session.advance_chain_tip(10000);
-        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u0"));
+        assert_eq!(
+            session.handle_command("(contract-call? .contract-2 get-x)")[0],
+            green!("u0")
+        );
         session.handle_command("(contract-call? .contract-2 incr)");
-        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u1"));
+        assert_eq!(
+            session.handle_command("(contract-call? .contract-2 get-x)")[0],
+            green!("u1")
+        );
         assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u0)) (contract-call? .contract-2 get-x))")[0], green!("u0"));
 
         // advance chain tip again and test at-block
         session.advance_chain_tip(10);
-        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u1"));
+        assert_eq!(
+            session.handle_command("(contract-call? .contract-2 get-x)")[0],
+            green!("u1")
+        );
         session.handle_command("(contract-call? .contract-2 incr)");
-        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u2"));
+        assert_eq!(
+            session.handle_command("(contract-call? .contract-2 get-x)")[0],
+            green!("u2")
+        );
         assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u10000)) (contract-call? .contract-2 get-x))")[0], green!("u1"));
     }
 }

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -1318,19 +1318,21 @@ mod tests {
                     (var-set x (+ (var-get x) u1))
                     (ok (var-get x))))");
         
-        // assert that the initial state of the data-var is 0
+        // assert data-var is set to 0
         assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u0"));
 
-        // advance the chain tip by 1
-        session.advance_chain_tip(1);
-
-        // increment the data-var
+        // advance chain tip and test at-block
+        session.advance_chain_tip(10000);
+        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u0"));
         session.handle_command("(contract-call? .contract-2 incr)");
-
-        // assert that the data-var was incremented
         assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u1"));
-
-        // assert that the data-var at block height 0 is 0
         assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u0)) (contract-call? .contract-2 get-x))")[0], green!("u0"));
+
+        // advance chain tip again and test at-block
+        session.advance_chain_tip(10);
+        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u1"));
+        session.handle_command("(contract-call? .contract-2 incr)");
+        assert_eq!(session.handle_command("(contract-call? .contract-2 get-x)")[0], green!("u2"));
+        assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u10000)) (contract-call? .contract-2 get-x))")[0], green!("u1"));
     }
 }


### PR DESCRIPTION
This PR improves upon the existing `Datastore` MARF emulation, enabling Clarity functions `at-block` and `get-block-info?`.

issues: #18, #20 #27