### PR TITLE
Fix: emulated MARF advance_chain_tip

### DIFF
--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -56,7 +56,11 @@ impl Datastore {
 
     pub fn advance_chain_tip(&mut self, count: u32) -> u32 {
         let cur_height = self.chain_height;
-        let current_lookup_id = self.block_id_lookup.get(&self.open_chain_tip).expect("Open chain tip missing in block id lookup table").clone();
+        let current_lookup_id = self
+            .block_id_lookup
+            .get(&self.open_chain_tip)
+            .expect("Open chain tip missing in block id lookup table")
+            .clone();
 
         for i in 1..=count {
             let height = cur_height + i;

--- a/src/clarity/database/datastore.rs
+++ b/src/clarity/database/datastore.rs
@@ -56,12 +56,13 @@ impl Datastore {
 
     pub fn advance_chain_tip(&mut self, count: u32) -> u32 {
         let cur_height = self.chain_height;
+        let current_lookup_id = self.block_id_lookup.get(&self.open_chain_tip).expect("Open chain tip missing in block id lookup table").clone();
 
         for i in 1..=count {
             let height = cur_height + i;
             let id = height_to_id(height);
 
-            self.block_id_lookup.insert(id, self.open_chain_tip);
+            self.block_id_lookup.insert(id, current_lookup_id);
             self.height_at_chain_tip.insert(id, height);
         }
 

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -1309,7 +1309,10 @@ mod tests {
         assert_eq!(session.handle_command("(at-block (unwrap-panic (get-block-info? id-header-hash u5000)) (contract-call? .contract-2 get-x))")[0], green!("u0"));
 
         // advance chain tip again and test at-block
+        // do this twice to make sure that the lookup table is being updated properly
         session.advance_chain_tip(10);
+        session.advance_chain_tip(10);
+
         assert_eq!(
             session.handle_command("(contract-call? .contract-2 get-x)")[0],
             green!("u1")


### PR DESCRIPTION
Fixes #54.

When advancing the chain tip, the datastore was not updating the `block_id_lookup` map correctly.