### PR TITLE
ci: add workflow to open PR after release

### DIFF
--- a/.github/workflows/open-develop-pr.yaml
+++ b/.github/workflows/open-develop-pr.yaml
@@ -1,0 +1,35 @@
+##
+## Auto-opens a PR from main -> develop after a release has been published.
+##
+
+name: Open Develop PR
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: Upsteam develop branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout clarity-repl
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Open pull request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: main
+          destination_branch: develop
+          pr_title: "chore: update develop branch"
+          pr_body: |
+            :robot: This is an automated pull request created from a new release in [clarity-repl](https://github.com/hirosystems/clarity-repl/releases).
+
+            Updates the develop branch from main.
+          pr_reviewer: lgalabru
+          pr_assignee: lgalabru
+          github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Automatically merge main back into develop after a release.