### PR TITLE
ci: fix workflow quotes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,12 @@ on:
   pull_request:
   push:
     tags:
-      - "v*"
+      - 'v*'
     paths-ignore:
-      - "**/CHANGELOG.md"
-      - "**/package.json"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
+      - '**/CHANGELOG.md'
+      - '**/package.json'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
     branches:
       - main
       - develop


### PR DESCRIPTION
For some reason it seems the paths-ignore rule is not being considered upon releases, which causes the release process to abruptly end by a new workflow instance that cancels the running one. All of the GH docs show to use single quotes, so it may help, although I'm not positive.