### PR TITLE
fix: resolve CI failure for forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,8 +126,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          # Necessary for Semantic Release
-          token: ${{ secrets.GH_TOKEN }}
+          # GH_TOKEN is necessary for Semantic Release, but for PRs to develop,
+          # (including from forks) GITHUB_TOKEN is good enough.
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The GH_TOKEN secret is required for the semantic release step, but that
only runs on a PR to main. Since forks can open a PR to develop, which
needs to run the build and testing, but not the semantic release, we can
use the GITHUB_TOKEN instead. Fix from @CharlieC3.