### PR TITLE
Orchestra requirements + various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ getrandom = { version = "0.2.3", features = ["js"] }
 rand_pcg = "0.3.1"
 rand_seeder = "0.2.2"
 atty = "0.2.14"
-tokio = { version = "=1.14.0", features = ["rt", "rt-multi-thread"], optional = true }
+tokio = { version = "=1.15.0", features = ["rt", "rt-multi-thread"], optional = true }
 
 # CLI
 pico-args = { version = "0.4.0", optional = true }

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -159,7 +159,7 @@ impl ClarityInterpreter {
                     spans: vec![],
                     suggestion: None,
                 }]);
-            },
+            }
         };
 
         result.diagnostics = diagnostics;
@@ -463,10 +463,14 @@ https://github.com/hirosystems/clarinet/issues/new/choose"#
                 Ok(Some(value)) => value,
                 Ok(None) => Value::none(),
                 Err(e) => {
-                    return Err((format!(
-                        "Runtime error while interpreting {}: {:?}",
-                        contract_identifier, e
-                    ), None, None));
+                    return Err((
+                        format!(
+                            "Runtime error while interpreting {}: {:?}",
+                            contract_identifier, e
+                        ),
+                        None,
+                        None,
+                    ));
                 }
             };
 

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -153,12 +153,13 @@ impl ClarityInterpreter {
                 return Err(diagnostics);
             }
             Err((e, _, _)) => {
-                return Err(vec![Diagnostic {
+                diagnostics.push(Diagnostic {
                     level: Level::Error,
                     message: format!("Runtime Error: {}", e),
                     spans: vec![],
                     suggestion: None,
-                }]);
+                });
+                return Err(diagnostics);
             }
         };
 

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -152,7 +152,14 @@ impl ClarityInterpreter {
                 diagnostics.push(diagnostic);
                 return Err(diagnostics);
             }
-            Err(_) => return Err(diagnostics),
+            Err((e, _, _)) => {
+                return Err(vec![Diagnostic {
+                    level: Level::Error,
+                    message: format!("Runtime Error: {}", e),
+                    spans: vec![],
+                    suggestion: None,
+                }]);
+            },
         };
 
         result.diagnostics = diagnostics;
@@ -456,14 +463,10 @@ https://github.com/hirosystems/clarinet/issues/new/choose"#
                 Ok(Some(value)) => value,
                 Ok(None) => Value::none(),
                 Err(e) => {
-                    println!(
-                        "{}",
-                        red!(format!(
-                            "Runtime error while interpreting {}: {:?}",
-                            contract_identifier, e
-                        ))
-                    );
-                    std::process::exit(1);
+                    return Err((format!(
+                        "Runtime error while interpreting {}: {:?}",
+                        contract_identifier, e
+                    ), None, None));
                 }
             };
 

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -456,7 +456,13 @@ https://github.com/hirosystems/clarinet/issues/new/choose"#
                 Ok(Some(value)) => value,
                 Ok(None) => Value::none(),
                 Err(e) => {
-                    println!("{}", red!(format!("Runtime error while interpreting {}: {:?}", contract_identifier, e)));
+                    println!(
+                        "{}",
+                        red!(format!(
+                            "Runtime error while interpreting {}: {:?}",
+                            contract_identifier, e
+                        ))
+                    );
                     std::process::exit(1);
                 }
             };

--- a/src/repl/interpreter.rs
+++ b/src/repl/interpreter.rs
@@ -452,12 +452,12 @@ https://github.com/hirosystems/clarinet/issues/new/choose"#
             });
 
             execution_result.coverage = global_context.coverage_reporting.take();
-
             let value = match result {
                 Ok(Some(value)) => value,
                 Ok(None) => Value::none(),
                 Err(e) => {
-                    return Err(("Runtime".to_string(), None, Some(e)));
+                    println!("{}", red!(format!("Runtime error while interpreting {}: {:?}", contract_identifier, e)));
+                    std::process::exit(1);
                 }
             };
 

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -340,13 +340,11 @@ impl Session {
                     true,
                     None,
                 ) {
-                    Ok((mut logs, _)) => {
-                        output.append(&mut logs)
-                    }
+                    Ok((mut logs, _)) => output.append(&mut logs),
                     Err(ref mut result) => {
                         output_err.append(result);
                         break;
-                    },
+                    }
                 };
             }
 
@@ -506,7 +504,7 @@ impl Session {
 
         // The cost of maintaining the "requirements" / "links" feature on WASM builds
         // is pretty high, and the amount of code duplicated is very important.
-        // We will timeshift through git and restore this feature if we 
+        // We will timeshift through git and restore this feature if we
         // can identify a concrete use case in the future
 
         if !self.settings.initial_contracts.is_empty() {

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -18,10 +18,10 @@ use crate::{clarity::diagnostic::Diagnostic, repl::settings::InitialContract};
 use ansi_term::{Colour, Style};
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::fmt;
-use std::num::ParseIntError;
-use std::path::PathBuf;
 use std::fs::{self, File};
 use std::io::Write;
+use std::num::ParseIntError;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "cli")]
@@ -126,17 +126,17 @@ impl Session {
                     }
                 }
             };
-    
+
             let request_url = format!(
                 "{host}/v2/contracts/source/{addr}/{name}?proof=0",
                 host = stacks_node_addr,
                 addr = contract_deployer,
                 name = contract_name
             );
-    
+
             let response = fetch_contract(request_url).await;
-    
-             response.source.to_string()
+
+            response.source.to_string()
         } else {
             contract_source.unwrap()
         };
@@ -322,7 +322,7 @@ impl Session {
                 for (contract_id, code, _) in contracts.into_iter() {
                     if !retrieved.contains(&contract_id) {
                         retrieved.insert(contract_id.clone());
-                        linked_contracts.push((contract_id, code));                        
+                        linked_contracts.push((contract_id, code));
                     }
                 }
             }

--- a/src/repl/settings.rs
+++ b/src/repl/settings.rs
@@ -65,4 +65,5 @@ pub struct SessionSettings {
     pub analysis: Vec<String>,
     pub lazy_initial_contracts_interpretation: bool,
     pub parser_version: u32,
+    pub disk_cache_enabled: bool,
 }

--- a/src/repl/settings.rs
+++ b/src/repl/settings.rs
@@ -63,5 +63,6 @@ pub struct SessionSettings {
     pub initial_deployer: Option<Account>,
     pub scoping_contract: Option<String>,
     pub analysis: Vec<String>,
+    pub lazy_initial_contracts_interpretation: bool,
     pub parser_version: u32,
 }


### PR DESCRIPTION
I'm working on sharing Orchestra, and this effort involves opening some PR on the REPL and Clarinet. With this PR, we're adding:
- ability to save a contract in the analysis database, without executing the contract
- update of Tokio
- iteration on `requirements`: a stable version of this feature could be very helpful in the context of Orchestra. I've been using this repo https://github.com/friedger/clarity-catamaranswaps/pull/2 for stressing this feature, and ended up fixing a bug in the dependency graph traversal + added the ability to cache on disk required contracts.