### PR TITLE
fix: append output from initial contracts

### DIFF
--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -280,6 +280,7 @@ impl Session {
                             self.get_accounts(&mut output);
                         }
                     }
+                    output.append(res);
                     contracts.append(initial_contracts);
                 }
                 Err(ref mut res) => {


### PR DESCRIPTION
The output from the initial contracts got dropped with the changes for
lazy interpretation. This is just restoring that output.