### PR TITLE
fix: rustls was not properly enabled (openssl c lib was being used)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "=1.15.0", features = ["rt", "rt-multi-thread"], optional = 
 pico-args = { version = "0.4.0", optional = true }
 rustyline = { version = "9.1.1", optional = true }
 prettytable-rs = { version = "0.8.0", optional = true }
-reqwest = { version = "0.11", features = ["json", "rustls"], optional = true }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
 # WASM
 wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
The `reqwest` dependency was unintentionally using OpenSSL (a C library) instead of `rustls` (pure rust library). This was causing compilation issues on various platforms.

It looks like the original intent was to use `rustls` but the toml was misconfigured. 

The following config changes are required to use rustls and disable openssl:
```toml
reqwest = { default-features = false, features = ["rustls-tls"] }
```


-----
Before toml fix:
```
cargo tree -i openssl-sys            
openssl-sys v0.9.72
├── native-tls v0.2.8
│   ├── hyper-tls v0.5.0
│   │   └── reqwest v0.11.9
│   │       └── clarity-repl v0.22.1 (/Users/matt/Projects/clarity-repl)
│   ├── reqwest v0.11.9 (*)
│   └── tokio-native-tls v0.3.0
│       ├── hyper-tls v0.5.0 (*)
│       └── reqwest v0.11.9 (*)
└── openssl v0.10.38
    └── native-tls v0.2.8 (*)
```

After toml fix:
```
cargo tree -i openssl-sys
    Updating crates.io index
error: package ID specification `openssl-sys` did not match any packages
```