### PR TITLE
fix: check for whitespace between exprs in list

### DIFF
--- a/src/repl/ast/parser/error.rs
+++ b/src/repl/ast/parser/error.rs
@@ -25,6 +25,7 @@ pub enum ParserError {
     IllegalClarityName(String),
     IllegalASCIIString(String),
     IllegalUtf8String(String),
+    ExpectedWhitespace,
     // Notes
     NoteToMatchThis(Token),
 }
@@ -57,6 +58,7 @@ impl DiagnosableError for ParserError {
             IllegalClarityName(name) => format!("illegal clarity name, '{}'", name),
             IllegalASCIIString(s) => format!("illegal ascii string \"{}\"", s),
             IllegalUtf8String(s) => format!("illegal UTF8 string \"{}\"", s),
+            ExpectedWhitespace => "expected whitespace before expression".to_string(),
             NoteToMatchThis(token) => format!("to match this '{}'", token),
         }
     }


### PR DESCRIPTION
In the case where a list contains another list, there was previously no
error reported if there was no space before the '(' in the list, for
example:

```clarity
(define-public (foo)
    (ok(print "hello"))
)
```

This is now properly reported with the message, "expected whitespace
before expression."

Fixes #110