### PR TITLE
Add an execution tracer to the REPL

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,6 +87,28 @@ macro_rules! blue {
 }
 
 #[allow(unused_macros)]
+macro_rules! purple {
+    ($($arg:tt)*) => (
+        {
+            use atty::Stream;
+            use ansi_term::{Colour, Style};
+            if atty::is(Stream::Stdout) {
+                let colour = Colour::Purple.bold();
+                format!(
+                    "{}",
+                    colour.paint($($arg)*)
+                )
+            } else {
+                format!(
+                    "{}",
+                    $($arg)*
+                )
+            }
+        }
+    )
+}
+
+#[allow(unused_macros)]
 macro_rules! black {
     ($($arg:tt)*) => (
         {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -13,6 +13,8 @@ pub mod interpreter;
 pub mod session;
 pub mod settings;
 
+pub mod tracer;
+
 pub use interpreter::ClarityInterpreter;
 pub use session::Session;
 pub use settings::SessionSettings;

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -715,17 +715,21 @@ impl Session {
 
         let tracer = Tracer::new(snippet.to_string());
 
-        match self.formatted_interpretation(
+        match self.interpret(
             snippet.to_string(),
             None,
-            true,
             Some(vec![Box::new(tracer)]),
+            false,
             None,
         ) {
-            Ok((mut out, result)) => {
-                output.append(&mut out);
+            Ok(_) => (),
+            Err(mut diagnostics) => {
+                let lines = snippet.lines();
+                let formatted_lines: Vec<String> = lines.map(|l| l.to_string()).collect();
+                for d in diagnostics {
+                    output.append(&mut d.output("<snippet>", &formatted_lines));
+                }
             }
-            Err(mut result) => output.append(&mut result),
         };
     }
 

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -596,6 +596,8 @@ impl Session {
             #[cfg(feature = "cli")]
             cmd if cmd.starts_with("::debug") => self.debug(&mut output, cmd),
             #[cfg(feature = "cli")]
+            cmd if cmd.starts_with("::trace") => self.trace(&mut output, cmd),
+            #[cfg(feature = "cli")]
             cmd if cmd.starts_with("::reload") => self.reload(&mut output),
 
             snippet => {
@@ -700,6 +702,31 @@ impl Session {
             Err(result) => result,
         };
         output.append(&mut result);
+    }
+
+    #[cfg(feature = "cli")]
+    pub fn trace(&mut self, output: &mut Vec<String>, cmd: &str) {
+        use super::tracer::Tracer;
+
+        let snippet = match cmd.split_once(" ") {
+            Some((_, snippet)) => snippet,
+            _ => return output.push(red!("Usage: ::trace <expr>")),
+        };
+
+        let tracer = Tracer::new(snippet.to_string());
+
+        match self.formatted_interpretation(
+            snippet.to_string(),
+            None,
+            true,
+            Some(vec![Box::new(tracer)]),
+            None,
+        ) {
+            Ok((mut out, result)) => {
+                output.append(&mut out);
+            }
+            Err(mut result) => output.append(&mut result),
+        };
     }
 
     #[cfg(feature = "cli")]

--- a/src/repl/tracer.rs
+++ b/src/repl/tracer.rs
@@ -1,0 +1,206 @@
+use crate::clarity::errors::Error;
+use crate::clarity::eval;
+use crate::clarity::functions::define::DefineFunctions;
+use crate::clarity::functions::NativeFunctions;
+use crate::clarity::types::PrincipalData;
+use crate::clarity::{
+    contexts::{Environment, LocalContext},
+    types::Value,
+    EvalHook, SymbolicExpression, SymbolicExpressionType,
+};
+use crate::repl::tracer::SymbolicExpressionType::List;
+
+pub struct Tracer {
+    snippet: String,
+    stack: Vec<u64>,
+    arg_count: Vec<usize>,
+    arg_stack: Vec<Vec<u64>>,
+    pending_call: Vec<String>,
+    pending_args: Vec<String>,
+}
+
+impl Tracer {
+    pub fn new(snippet: String) -> Tracer {
+        println!("{}  {}", snippet, black!("<console>"));
+        Tracer {
+            snippet,
+            stack: vec![0],
+            arg_count: Vec::new(),
+            arg_stack: Vec::new(),
+            pending_call: Vec::new(),
+            pending_args: Vec::new(),
+        }
+    }
+
+    fn collect_args(&mut self, num: usize) {
+        self.arg_count.push(num);
+        self.arg_stack.push(Vec::new());
+    }
+}
+
+impl EvalHook for Tracer {
+    fn will_begin_eval(
+        &mut self,
+        env: &mut Environment,
+        context: &LocalContext,
+        expr: &SymbolicExpression,
+    ) {
+        if let Some(arg_count) = self.arg_count.last() {
+            if let Some(arg_stack) = self.arg_stack.last_mut() {
+                if arg_stack.is_empty() {
+                    arg_stack.push(expr.id);
+                }
+            }
+        }
+
+        let list = match &expr.expr {
+            List(list) => list,
+            _ => return,
+        };
+        if let Some((function_name, args)) = list.split_first() {
+            if let Some(function_name) = function_name.match_atom() {
+                if DefineFunctions::lookup_by_name(function_name).is_some() {
+                    return;
+                } else if let Some(native_function) = NativeFunctions::lookup_by_name(function_name)
+                {
+                    match native_function {
+                        NativeFunctions::ContractCall => {
+                            let call = format!(
+                                "{}├── {}  {}",
+                                "│   ".repeat(self.stack.len() - self.pending_call.len() - 1),
+                                expr,
+                                black!(format!(
+                                    "{}:{}:{}",
+                                    env.contract_context.contract_identifier.name,
+                                    expr.span.start_line,
+                                    expr.span.start_column,
+                                )),
+                            );
+
+                            let mut lines = Vec::new();
+                            if args[0].match_atom().is_some() {
+                                let callee = if let Ok(value) = eval(&args[0], env, context) {
+                                    value.to_string()
+                                } else {
+                                    "?".to_string()
+                                };
+                                lines.push(format!(
+                                    "{}│ {}",
+                                    "│   ".repeat(self.stack.len() - self.pending_call.len()),
+                                    purple!(format!("↳ callee: {}", callee)),
+                                ));
+                            }
+
+                            if args.len() > 0 {
+                                lines.push(format!(
+                                    "{}│ {}",
+                                    "│   ".repeat(self.stack.len() - self.pending_call.len()),
+                                    purple!("↳ args:"),
+                                ));
+                                self.pending_call.push(call);
+                                self.pending_args.push(lines.join("\n"));
+                                self.collect_args(args.len() - 2);
+                            } else {
+                                println!(
+                                    "{}{}",
+                                    "│   ".repeat(self.stack.len() - self.pending_call.len()),
+                                    call
+                                );
+                            }
+                        }
+                        _ => return,
+                    }
+                } else {
+                    // Call user-defined function
+                    let call = format!(
+                        "{}├── {}  {}",
+                        "│   ".repeat(self.stack.len() - self.pending_call.len() - 1),
+                        expr,
+                        black!(format!(
+                            "{}:{}:{}",
+                            env.contract_context.contract_identifier.name,
+                            expr.span.start_line,
+                            expr.span.start_column,
+                        )),
+                    );
+                    self.pending_args.push(format!(
+                        "{}│ {}",
+                        "│   ".repeat(self.stack.len() - self.pending_call.len()),
+                        purple!("↳ args:"),
+                    ));
+                    if args.len() > 0 {
+                        self.pending_call.push(call);
+                        self.collect_args(args.len());
+                    } else {
+                        println!(
+                            "{}{}",
+                            "│   ".repeat(self.stack.len() - self.pending_call.len()),
+                            call
+                        );
+                    }
+                }
+            }
+        }
+        self.stack.push(expr.id);
+    }
+
+    fn did_finish_eval(
+        &mut self,
+        env: &mut Environment,
+        context: &LocalContext,
+        expr: &SymbolicExpression,
+        res: &Result<Value, Error>,
+    ) {
+        if let Some(last) = self.stack.last() {
+            if *last == expr.id {
+                if let Ok(value) = res {
+                    println!(
+                        "{}└── {}",
+                        "│   ".repeat(self.stack.len() - self.pending_call.len() - 1),
+                        blue!(value.to_string())
+                    );
+                }
+                self.stack.pop();
+            }
+        }
+
+        // Collect argument values
+        if let (Some(arg_count), Some(arg_stack)) =
+            (self.arg_count.last(), self.arg_stack.last_mut())
+        {
+            if let Some(arg) = arg_stack.last() {
+                if *arg == expr.id {
+                    let arg_count = self.arg_count.pop().unwrap() - 1;
+                    if let Ok(value) = res {
+                        self.pending_args
+                            .last_mut()
+                            .unwrap()
+                            .push_str(format!(" {}", value).as_str());
+                    }
+                    // If this was the last argument, print it out and pop the stack
+                    if arg_count == 0 {
+                        let call = self.pending_call.pop().unwrap();
+                        println!("{}", call);
+                        println!("{}", self.pending_args.pop().unwrap().to_string());
+                        self.arg_stack.pop();
+                    } else {
+                        // Pop this arg and push the decremented arg count back on the stack
+                        self.arg_count.push(arg_count);
+                        arg_stack.pop();
+                    }
+                }
+            }
+        }
+    }
+
+    fn did_complete(&mut self, result: core::result::Result<&mut super::ExecutionResult, String>) {
+        match result {
+            Ok(result) => {
+                if let Some(value) = &result.result {
+                    println!("└── {}", blue!(format!("{}", value)));
+                }
+            }
+            Err(e) => println!("{}", e),
+        }
+    }
+}


### PR DESCRIPTION
```
>> ::trace (contract-call? .foo hello .bar)
(contract-call? .foo hello .bar)  <console>
├── ( add 4 2 )  foo:23:19
│   │ ↳ args: 4 2
│   └── 6
├── ( add 3 ( add 4 2 ) )  foo:23:12
│   │ ↳ args: 3 6
│   └── 9
├── ( set-my-var 7 )  foo:24:12
│   │ ↳ args: 7
│   └── true
├── ( contract-call? ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.bar do-something ( var-get myVar ) )  foo:25:14
│   │ ↳ args: 7
│   ├── ( max10 val )  bar:19:24
│   │   │ ↳ args: 7
│   │   └── 7
│   └── (ok 0)
├── ( contract-call? b do-something 42 )  foo:26:5
│   │ ↳ callee: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.bar
│   │ ↳ args: 42
│   ├── ( max10 val )  bar:19:24
│   │   │ ↳ args: 42
│   │   └── 10
│   └── (ok 7)
└── (ok 7)
Events emitted
{"type":"contract_event","contract_event":{"contract_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo","topic":"print","value":"9"}}
{"type":"contract_event","contract_event":{"contract_identifier":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo","topic":"print","value":"true"}}
(ok 7)
```