### PR TITLE
feat: allow pasting of multiple lines

### DIFF
--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -119,19 +119,13 @@ impl Terminal {
                     let input = input_buffer.join(" ");
                     match complete_input(&input) {
                         Ok(Input::Complete(forms)) => {
-                            let one_expr = forms.len() == 1;
-                            for expr in forms {
-                                if !one_expr {
-                                    println!(";; {}", expr);
-                                }
-                                let output = self.session.handle_command(expr);
-                                for line in output {
-                                    println!("{}", line);
-                                }
-                                prompt = String::from(">> ");
-                                self.session.executed.push(expr.to_string());
-                                editor.add_history_entry(expr);
+                            let output = self.session.handle_command(&input);
+                            for line in output {
+                                println!("{}", line);
                             }
+                            prompt = String::from(">> ");
+                            self.session.executed.push(input.to_string());
+                            editor.add_history_entry(input);
                             input_buffer.clear();
                         }
                         Ok(Input::Incomplete(str)) => {
@@ -139,6 +133,7 @@ impl Terminal {
                         }
                         Err((expected, got)) => {
                             println!("Error: expected closing {}, got {}", expected, got);
+                            prompt = String::from(">> ");
                             input_buffer.pop();
                         }
                     }

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -35,6 +35,9 @@ fn complete_input(str: &str) -> Result<Input, (char, char)> {
             '(' | '{' => {
                 if !in_string {
                     brackets.push(character);
+                    // skip whitespace between the previous form's
+                    // closing paren (if there is one) and the current
+                    // form's opening paren
                     match (character, paren_count) {
                         ('(', 0) => {
                             paren_count += 1;
@@ -116,8 +119,11 @@ impl Terminal {
                     let input = input_buffer.join(" ");
                     match complete_input(&input) {
                         Ok(Input::Complete(forms)) => {
+                            let one_expr = forms.len() == 1;
                             for expr in forms {
-                                println!(";; {}", expr);
+                                if !one_expr {
+                                    println!(";; {}", expr);
+                                }
                                 let output = self.session.handle_command(expr);
                                 for line in output {
                                     println!("{}", line);

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -8,22 +8,65 @@ use std::io::{stdin, stdout, Write};
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 const HISTORY_FILE: Option<&'static str> = option_env!("CLARITY_REPL_HISTORY_FILE");
 
-fn complete_input(str: &str) -> Result<Option<char>, (char, char)> {
+enum Input<'a> {
+    Incomplete(char),
+    Complete(Vec<&'a str>),
+}
+
+fn complete_input(str: &str) -> Result<Input, (char, char)> {
+    let mut forms: Vec<&str> = vec![];
+    let mut paren_count = 0;
+    let mut last_pos = 0;
+
     let mut brackets = vec![];
-    for character in str.chars() {
+    let mut skip_next = false;
+    let mut in_string = false;
+
+    for (pos, character) in str.char_indices() {
         match character {
-            '(' | '{' => brackets.push(character),
-            ')' | '}' => match (brackets.pop(), character) {
-                (Some('('), '}') => return Err((')', '}')),
-                (Some('{'), ')') => return Err(('}', ')')),
-                _ => {}
-            },
+            '\\' => skip_next = true,
+            '"' => {
+                if skip_next {
+                    skip_next = false
+                } else {
+                    in_string = !in_string
+                }
+            }
+            '(' | '{' => {
+                if !in_string {
+                    brackets.push(character);
+                    match (character, paren_count) {
+                        ('(', 0) => {
+                            paren_count += 1;
+                            last_pos = pos
+                        }
+                        ('(', _) => paren_count += 1,
+                        _ => {}
+                    }
+                }
+            }
+            ')' | '}' => {
+                if !in_string {
+                    match (brackets.pop(), character) {
+                        (Some('('), '}') => return Err((')', '}')),
+                        (Some('{'), ')') => return Err(('}', ')')),
+                        _ => {}
+                    };
+                    if character == ')' {
+                        paren_count -= 1;
+                        if paren_count == 0 {
+                            forms.push(&str[last_pos..pos + 1]);
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
+
     match brackets.last() {
-        Some(char) => Ok(Some(*char)),
-        _ => Ok(None),
+        Some(char) => Ok(Input::Incomplete(*char)),
+        _ => Ok(Input::Complete(forms)),
     }
 }
 
@@ -70,19 +113,22 @@ impl Terminal {
                 Ok(command) => {
                     ctrl_c_acc = 0;
                     input_buffer.push(command);
-                    let input = input_buffer.join("\n");
+                    let input = input_buffer.join(" ");
                     match complete_input(&input) {
-                        Ok(None) => {
-                            let output = self.session.handle_command(&input);
-                            for line in output {
-                                println!("{}", line);
+                        Ok(Input::Complete(forms)) => {
+                            for expr in forms {
+                                println!(";; {}", expr);
+                                let output = self.session.handle_command(expr);
+                                for line in output {
+                                    println!("{}", line);
+                                }
+                                prompt = String::from(">> ");
+                                self.session.executed.push(expr.to_string());
+                                editor.add_history_entry(expr);
+                                input_buffer.clear();
                             }
-                            prompt = String::from(">> ");
-                            self.session.executed.push(input.clone());
-                            editor.add_history_entry(&input);
-                            input_buffer.clear();
                         }
-                        Ok(Some(str)) => {
+                        Ok(Input::Incomplete(str)) => {
                             prompt = format!("{}.. ", str);
                         }
                         Err((expected, got)) => {

--- a/src/frontend/terminal.rs
+++ b/src/frontend/terminal.rs
@@ -125,8 +125,8 @@ impl Terminal {
                                 prompt = String::from(">> ");
                                 self.session.executed.push(expr.to_string());
                                 editor.add_history_entry(expr);
-                                input_buffer.clear();
                             }
+                            input_buffer.clear();
                         }
                         Ok(Input::Incomplete(str)) => {
                             prompt = format!("{}.. ", str);


### PR DESCRIPTION
This fixes an interactive clarinet bug, and allows for pasting multiple
lines into the console.  I've tested it lightly by copying/pasting
several lines from another window into clarinet console.

There are a couple of changes in behavior.

* The console echos back the form before its result:

    >> (concat "a " " b") (concat "r" "d")
    ;; (concat "a " " b")
    "a  b"
    ;; (concat "r" "d")
    "rd"
    >>

* Multiple expressions on the same line end up as separate entries
  in the history.  Pressing the up arrow after the above input
  brings up only the second form, not both of them.  This might not
  be desirable.

* This also works, though i'm not sure if it should:

    (concat "a " " b")(concat "r" "d")

Without my change, this results in

    >> (concat "a " " b")(concat "r" "d")
    error: Expected whitespace or a close parens. Found: '('
    warning: conflict between parser versions, reverting to parser v1
    Help improve clarinet by sharing the code that triggered this warning:
    https://github.com/hirosystems/clarinet/issues/new/choose

The bug: the complete_input function did not check if the parens
were inside strings before trying to match them.  This is valid
code that it rejected:

    (concat "abc" "de}f")

Fixes: #115