### PR TITLE
fix: remove unhelpful dependency error

### DIFF
--- a/src/analysis/ast_dependency_detector.rs
+++ b/src/analysis/ast_dependency_detector.rs
@@ -227,7 +227,10 @@ impl<'a> ASTDependencyDetector<'a> {
                 let dep_id = match lookup.get(&dep.contract_id) {
                     Some(id) => id,
                     None => {
-                        return Err(CheckErrors::NoSuchContract(dep.contract_id.to_string()).into());
+                        // No need to report an error here, it will be caught
+                        // and reported with proper location information by the
+                        // later analyses. Just skip it.
+                        continue;
                     }
                 };
                 graph.add_directed_edge(*contract_id, *dep_id);


### PR DESCRIPTION
Instead of reporting an error in `order_contracts` when a contract is
not found, we now just skip that dependency. Reporting an error at that
point is not useful, because a better error with proper location
information can be reported by the later analysis.

See hirosystems/clarinet#396