### PR TITLE
fix: don't create a dependency for `__transient`

### DIFF
--- a/src/analysis/ast_dependency_detector.rs
+++ b/src/analysis/ast_dependency_detector.rs
@@ -264,6 +264,12 @@ impl<'a> ASTDependencyDetector<'a> {
         if self.preloaded.contains_key(from) {
             return;
         }
+
+        // Ignore the placeholder contract.
+        if to.name.starts_with("__") {
+            return;
+        }
+
         if let Some(set) = self.dependencies.get_mut(from) {
             set.add_dependency(to.clone(), self.top_level);
         } else {


### PR DESCRIPTION
The `__transient` contract is used as a placeholder when the principal
is invalid, so just ignore this in the dependency detector, and a proper
error will be generated for it.