### PR TITLE
fix: avoid crash from too few args passed

### DIFF
--- a/src/analysis/ast_dependency_detector.rs
+++ b/src/analysis/ast_dependency_detector.rs
@@ -358,10 +358,12 @@ impl<'a> ASTDependencyDetector<'a> {
         let mut dependencies = Vec::new();
         for (i, arg) in arg_types.iter().enumerate() {
             if matches!(arg, TypeSignature::TraitReferenceType(_)) {
-                if let Some(Value::Principal(PrincipalData::Contract(contract))) =
-                    args[i].match_literal_value()
-                {
-                    dependencies.push(contract.clone());
+                if args.len() > i {
+                    if let Some(Value::Principal(PrincipalData::Contract(contract))) =
+                        args[i].match_literal_value()
+                    {
+                        dependencies.push(contract.clone());
+                    }
                 }
             }
         }
@@ -611,10 +613,12 @@ impl<'a> ASTVisitor<'a> for ASTDependencyDetector<'a> {
         {
             for (i, arg) in arg_types.iter().enumerate() {
                 if matches!(arg, TypeSignature::TraitReferenceType(_)) {
-                    if let Some(Value::Principal(PrincipalData::Contract(contract))) =
-                        args[i].match_literal_value()
-                    {
-                        dependencies.push(contract);
+                    if args.len() > i {
+                        if let Some(Value::Principal(PrincipalData::Contract(contract))) =
+                            args[i].match_literal_value()
+                        {
+                            dependencies.push(contract);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If an argument is missing in a call, and that parameter has a trait
type, the dependency checker would crash when trying to retrieve the
argument to check it. This fix checks the argument count first to skip
this case, since the error should be reported by the call-checker.